### PR TITLE
Ignore some files... but include build

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+src/
+docs/
+tslint.json
+tsconfig.json
+yarn.lock
+.editorconfig

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "Filesystem abstraction library",
   "main": "build/index.js",
+  "files": [
+    "./build"
+  ],
   "scripts": {
     "build": "rimraf build && npm run lint && tsc",
     "test": "mocha --require ts-node/register src/**/*.test.ts",


### PR DESCRIPTION
If you try to `npm install` this, the `build` folder is missing... which is bad. This (should?) fix it.